### PR TITLE
Add policies methods and constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To start using a policy from the package you just have to import the package
 ```
 The package has the following constants:
 - **TestPolicy**: Implements a policy for testing purposes
+- **CoopPolicy**: Implements a policy for cooop roles
 
 Each constant is of type policy, which has two methods:   
 ### GetPolicyConfPath ###

--- a/coop/coop.conf
+++ b/coop/coop.conf
@@ -1,0 +1,8 @@
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = r.sub == p.sub && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)

--- a/coop/coop.csv
+++ b/coop/coop.csv
@@ -1,0 +1,4 @@
+p, country, /api/v1/countries/:country_id/sectors, GET
+p, country, /api/v1/countries/:country_id/sectors/:sector_id, GET
+p, country, /api/v1/countries/:country_id/sectors/:sector_id/categories
+p, country, /api/v1/countries/:country_id/sectors/:sector_id/categories/:category_id

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/epa-datos/policies
+
+go 1.13

--- a/policies.go
+++ b/policies.go
@@ -1,0 +1,27 @@
+package policies
+
+import (
+	"os"
+)
+
+var basePath = os.Getenv("GOPATH") + "/src/github.com/epa-datos/policies/"
+
+type policy string
+
+type Policy interface {
+	GetPolicyConfPath() string
+	GetPolicyCsvPath() string
+}
+
+const (
+	TestPolicy = policy("test")
+	CoopPolicy = policy("coop")
+)
+
+func (p policy) GetPolicyConfPath() string {
+	return basePath + string(p) + "/" + string(p) + ".conf"
+}
+
+func (p policy) GetPolicyCsvPath() string {
+	return basePath + string(p) + "/" + string(p) + ".csv"
+}

--- a/test/test.conf
+++ b/test/test.conf
@@ -1,0 +1,8 @@
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = r.sub == p.sub && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act) 

--- a/test/test.csv
+++ b/test/test.csv
@@ -1,0 +1,4 @@
+p, country, /test/countries/:country_id, GET
+p, country, /test/countries, GET
+p, retail, test/retailers/:retail_id, GET
+p, segment, test/countries/:country_id/retailers, GET


### PR DESCRIPTION
# Problem Description
- We needed a package to store the different policies to be used in projects

# Features
- Add policy constants and methods to get policy file paths
- Add test policy for testing purposes
- Add coop policy (currently including country endpoints only)

# Where this change will be used
- This change will be used when using casbin policy enforcer 

# More details
- You can refer to the README.md file for more details on how to use the package