### PR TITLE
Admin policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Problem Description
+- 
+-
+
+# Features
+-
+-
+
+# Bug Fixes
+-
+-
+
+# Where this change will be used
+-
+-
+
+# More details
+- Add images, diagrams or resources to ilustrate your changes
+-

--- a/coop/coop.csv
+++ b/coop/coop.csv
@@ -1,4 +1,3 @@
-p, country, /api/v1/countries/:country_id/sectors, GET
-p, country, /api/v1/countries/:country_id/sectors/:sector_id, GET
-p, country, /api/v1/countries/:country_id/sectors/:sector_id/categories
-p, country, /api/v1/countries/:country_id/sectors/:sector_id/categories/:category_id
+p, admin, /api/v1/users/:user_id, DELETE
+p, admin, /api/v1/users, GET
+p, admin, /api/v1/users/invitations, POST

--- a/coop/coop.csv
+++ b/coop/coop.csv
@@ -1,3 +1,4 @@
 p, admin, /api/v1/users/:user_id, DELETE
+p, admin, /api/v1/users/:user_id/roles
 p, admin, /api/v1/users, GET
 p, admin, /api/v1/users/invitations, POST

--- a/coop/coop.csv
+++ b/coop/coop.csv
@@ -1,4 +1,4 @@
 p, admin, /api/v1/users/:user_id, DELETE
-p, admin, /api/v1/users/:user_id/roles
+p, admin, /api/v1/users/:user_id/roles, GET
 p, admin, /api/v1/users, GET
 p, admin, /api/v1/users/invitations, POST


### PR DESCRIPTION
# Problem Description
- We need to restrict access to certain api endpoints so only admin users can see them

# Features
Add policy for:
- /users/:user_id DELETE
- /users/:user_id/roles GET
- /users GET
- /users/invitations POST

# Where this change will be used
- This change will be used in the policy enforcer middleware
