### PR TITLE
Change base path

### DIFF
--- a/coop/coop.csv
+++ b/coop/coop.csv
@@ -1,4 +1,12 @@
-p, admin, /api/v1/users/:user_id, DELETE
-p, admin, /api/v1/users/:user_id/roles, GET
 p, admin, /api/v1/users, GET
+p, admin, /api/v1/users/:user_id, DELETE
 p, admin, /api/v1/users/invitations, POST
+p, admin, /api/v1/users/invitations, GET
+p, admin, /api/v1/invitations/:invitation_id, DELETE
+p, admin, /api/v1/invitations/:invitation_id/resend, POST
+p, admin, /api/v1/roles, GET
+p, admin, /api/v1/countries, GET
+p, hp, /api/v1/countries, GET
+p, country, /api/v1/countries, GET
+
+

--- a/policies.go
+++ b/policies.go
@@ -4,7 +4,7 @@ import (
 	"os"
 )
 
-var basePath = os.Getenv("GOPATH") + "/src/github.com/epa-datos/policies/"
+var basePath = os.Getenv("POLICY_PATH")
 
 type policy string
 


### PR DESCRIPTION
# Problem Description
- Only admins are allowed to send request to invitations and some user endpoints
- Only admins, hp and country have access to country endpoints

# Features
- Add new endpoints to policy
- Make base path env variable

# Where this change will be used
- When making requests to API
