### PR TITLE
[COOP-54] Update COOP Policy to enable access to sentiment analysis section for hp roles

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -56,6 +56,7 @@ func (p policy) GetPolicyCsvPath() string {
 	p, admin, /api/v1/retailers/:retailer_id/google-my-business/*, POST
 	p, hp, /api/v1/omnichat/*, GET
 	p, hp, /api/v1/pc-selector/*, GET
+	p, hp, /api/v1/sentiment/*, GET
 	p, hp, /api/v1/indexed/*, GET
 	p, hp,/api/v1/countries, GET
 	p, hp, /api/v1/countries/*, GET


### PR DESCRIPTION
# Problem Description
- It is required to allow users with HP role to access sentiment analysis section. 

# Features
- COOP policy was updated for HP roles with `/api/v1/sentiment/*  GET`

# Where this change will be used
- Latam>Sentiment Analysis
