### PR TITLE
[COOP-7] Adding permissions update endpoint

### DIFF
--- a/coop/coop.csv
+++ b/coop/coop.csv
@@ -1,6 +1,7 @@
 p, admin, *, GET
 p, admin, /api/v1/users/:user_id, DELETE
 p, admin, /api/v1/users/invitations, POST
+p, admin, /api/v1/users/:user_id/permissions/update, PUT
 p, admin, /api/v1/invitations/:invitation_id, DELETE
 p, admin, /api/v1/invitations/:invitation_id/resend, POST
 p, hp, /api/v1/sentiment/*, GET

--- a/policies.go
+++ b/policies.go
@@ -51,6 +51,7 @@ func (p policy) GetPolicyCsvPath() string {
 	p, admin,/api/v1/users/:user_id/images,PUT
 	p, admin, /api/v1/users/:user_id, DELETE
 	p, admin, /api/v1/users/invitations, POST
+	p, admin, /api/v1/users/:user_id/permissions/update, PUT
 	p, admin, /api/v1/invitations/:invitation_id, DELETE
 	p, admin, /api/v1/invitations/:invitation_id/resend, POST
 	p, admin, /api/v1/retailers/:retailer_id/google-my-business/*, POST


### PR DESCRIPTION
# Problem Description
- In order to allow admin users to update users permissions, it is necessary to update policy by adding the PUT endpoint 


